### PR TITLE
OpenSsh text tail support

### DIFF
--- a/src/Crypto/PubKey/OpenSsh.hs
+++ b/src/Crypto/PubKey/OpenSsh.hs
@@ -12,15 +12,28 @@ import Control.Monad (void, replicateM)
 import Data.ByteString.Char8 (ByteString)
 
 import Data.Attoparsec.ByteString.Char8 (Parser, parseOnly, take, space,
-                                         isSpace, takeTill)
+                                         isSpace, takeTill, atEnd)
 import Data.Serialize (Get, getBytes, runGet, getWord32be, getWord8)
 import qualified Data.ByteString.Base64 as Base64
 import qualified Crypto.Types.PubKey.DSA as DSA
 import qualified Crypto.Types.PubKey.RSA as RSA
 
-data OpenSshPublicKey = OpenSshPublicKeyRsa RSA.PublicKey
-                      | OpenSshPublicKeyDsa DSA.PublicKey
+
+data OpenSshPublicKeyBody = OpenSshPublicKeyBodyRsa RSA.PublicKey
+                          | OpenSshPublicKeyBodyDsa DSA.PublicKey
     deriving (Eq, Show)
+
+type OpenSshTextTail = ByteString
+
+data OpenSshPublicKey = OpenSshPublicKeyRsa RSA.PublicKey (Maybe OpenSshTextTail)
+                      | OpenSshPublicKeyDsa DSA.PublicKey (Maybe OpenSshTextTail)
+    deriving (Eq, Show)
+
+makeFromBody :: OpenSshPublicKeyBody
+             -> (Maybe OpenSshTextTail)
+             -> OpenSshPublicKey
+makeFromBody (OpenSshPublicKeyBodyRsa rsaPubKey) = OpenSshPublicKeyRsa rsaPubKey
+makeFromBody (OpenSshPublicKeyBodyDsa dsaPubKey) = OpenSshPublicKeyDsa dsaPubKey
 
 data OpenSshPublicKeyType = OpenSshPublicKeyTypeRsa
                           | OpenSshPublicKeyTypeDsa
@@ -47,31 +60,37 @@ getInteger = do
     return $ fst $ flip foldl1 (zip ints ([0..] :: [Integer])) $
         \(a, _) (c, p) -> (c * (256 ^ p) + a, p)
 
-getOpenSshPublicKey :: Get OpenSshPublicKey
+getOpenSshPublicKey :: Get OpenSshPublicKeyBody
 getOpenSshPublicKey = do
     size <- fmap fromIntegral $ getWord32be
     getBytes size >>= readType >>= \typ -> case typ of
         OpenSshPublicKeyTypeRsa -> parseRsa
         OpenSshPublicKeyTypeDsa -> parseDsa
   where
-    parseRsa = do 
+    parseRsa = do
         e <- getInteger
         n <- getInteger
-        return $ OpenSshPublicKeyRsa $ RSA.PublicKey (calculateSize n) n e
+        return $ OpenSshPublicKeyBodyRsa $ RSA.PublicKey (calculateSize n) n e
     parseDsa = do
         p <- getInteger
         q <- getInteger
         g <- getInteger
         y <- getInteger
-        return $ OpenSshPublicKeyDsa $ DSA.PublicKey (p, g, q) y
+        return $ OpenSshPublicKeyBodyDsa $ DSA.PublicKey (p, g, q) y
 
 openSshPublicKeyParser :: Parser OpenSshPublicKey
 openSshPublicKeyParser = do
     _typ <- readType =<< take typeSize
     void space
     b64 <- takeTill isSpace
-    binary <- either fail return $ Base64.decode b64
-    either fail return $ runGet getOpenSshPublicKey binary
+    binary <- eitherFail $ Base64.decode b64
+    body <- eitherFail $ runGet getOpenSshPublicKey binary
+    openSshKeyTail <- atEnd >>= \end -> if end
+        then return Nothing
+        else space >> takeTill isSpace >>= return . Just
+    return $ makeFromBody body openSshKeyTail
+  where
+    eitherFail = either fail return
 
 parseOpenSshPublicKey :: ByteString -> Either String OpenSshPublicKey
 parseOpenSshPublicKey = parseOnly openSshPublicKeyParser


### PR DESCRIPTION
Optional text tail parse for ssh key format.
`ssh-rsa/ssh-dss <long-long-key> <!HERE!>`
