### PR TITLE
Allow base 4.7 (GHC 7.8)

### DIFF
--- a/crypto-pubkey-openssh.cabal
+++ b/crypto-pubkey-openssh.cabal
@@ -25,7 +25,7 @@ Library
   Hs-source-dirs:   src
   Ghc-options:      -Wall -fno-warn-orphans
   Default-language: Haskell2010
-  Build-depends:    base                       == 4.6.*  || == 4.5.*
+  Build-depends:    base                       == 4.7.* || == 4.6.*  || == 4.5.*
                   , bytestring                 == 0.10.* || == 0.9.*
                   , base64-bytestring          == 1.0.*
                   , cereal                     == 0.4.*


### PR DESCRIPTION
GHC 7.8 is coming, so it's time to bump the base build dep.  After this, build-test works fine.
